### PR TITLE
fix for "Redundant argument in printf"

### DIFF
--- a/mysqlsla/bin/mysqlsla
+++ b/mysqlsla/bin/mysqlsla
@@ -3035,7 +3035,7 @@ sub standard_report
          }
 
          # Print all values for this format line.
-         if(!$format_conditional || $value_resolved)
+         if(!$format_conditional && $value_resolved)
          {
             $values[$#values] =~ s/[\s\n]{1,}$//;  # remove trailing spaces and newlines from final value
             printf($$formats[$i], @values);


### PR DESCRIPTION
Perl version  5.26
OS:  Ubuntu 18.04.2 
mysql : MariaDB 10.1.38

With the original source, The program shows the message "Redundant argument in printf at /usr/local/bin/mysqlsla line 3035."  and than exit.  Missing "Query Abstract" and "Query Sample" for the first query and all output for the following queries. Here is a sample output [before.txt](https://github.com/daniel-nichter/hackmysql.com/files/3109376/before.txt). 

*************************************************************************************************************************************************
mysqlsla  --top 100 -lt slow /var/log/mysql/slow_query.log -Ai 100 --user root --password root --reports standard
Report for msl logs: /var/log/mysql/slow_query.log
4 queries total, 4 unique
Sorted by 't_sum'
Grand Totals: Time 78 s, Lock 0 s, Rows sent 746.71k, Rows Examined 600.94k
______________________________________________________________________ 001 ___
Count         : 1  (25.00%)
Time          : 33.02873 s total, 33.02873 s avg, 33.02873 s to 33.02873 s max  (42.50%)
Lock Time (s) : 22.156 ms total, 22.156 ms avg, 22.156 ms to 22.156 ms max  (7.71%)
Rows sent     : 746.71k avg, 746.71k to 746.71k max  (100.00%)
Rows examined : 938 avg, 938 to 938 max  (0.16%)
Database      : tpcc  QC_hit: No
Users         : 
	root@localhost  : 100.00% (1) of query, 75.00% (3) of all users
Redundant argument in printf at /usr/local/bin/mysqlsla line 3035.
*************************************************************************************************************************************************

After the modification, everything seems normal. Here is the sample output [after.txt](https://github.com/daniel-nichter/hackmysql.com/files/3109386/after.txt).

*************************************************************************************************************************************************
mysqlsla  --top 100 -lt slow /var/log/mysql/slow_query.log -Ai 100 --user root --password root --reports standard
Report for msl logs: /var/log/mysql/slow_query.log
4 queries total, 4 unique
Sorted by 't_sum'
Grand Totals: Time 78 s, Lock 0 s, Rows sent 746.71k, Rows Examined 600.94k
______________________________________________________________________ 001 ___
Count         : 1  (25.00%)
Time          : 33.02873 s total, 33.02873 s avg, 33.02873 s to 33.02873 s max  (42.50%)
Lock Time (s) : 22.156 ms total, 22.156 ms avg, 22.156 ms to 22.156 ms max  (7.71%)
Rows sent     : 746.71k avg, 746.71k to 746.71k max  (100.00%)
Rows examined : 938 avg, 938 to 938 max  (0.16%)
Database      : tpcc  QC_hit: No
Users         : 
	root@localhost  : 100.00% (1) of query, 75.00% (3) of all users
SELECT * FROM customer a, customer b;
select * from customer a, customer b;
______________________________________________________________________ 002 ___
Count         : 1  (25.00%)
Time          : 19.394835 s total, 19.394835 s avg, 19.394835 s to 19.394835 s max  (24.95%)
Lock Time (s) : 264.885 ms total, 264.885 ms avg, 264.885 ms to 264.885 ms max  (92.23%)
Rows sent     : 0 avg, 0 to 0 max  (0.00%)
Rows examined : 300.00k avg, 300.00k to 300.00k max  (49.92%)
Database      : tpcc  QC_hit: No
Users         : 
	root@localhost  : 100.00% (1) of query, 75.00% (3) of all users
SET timestamp=N; CREATE TABLE c2 AS SELECT * FROM customer;
SET timestamp=1556036325;
create table c2 as select * from customer;
______________________________________________________________________ 003 ___
Count         : 1  (25.00%)
Time          : 14.671241 s total, 14.671241 s avg, 14.671241 s to 14.671241 s max  (18.88%)
Lock Time (s) : 161 �s total, 161 �s avg, 161 �s to 161 �s max  (0.06%)
Rows sent     : 0 avg, 0 to 0 max  (0.00%)
Rows examined : 300.00k avg, 300.00k to 300.00k max  (49.92%)
Database      : tpcc  QC_hit: No
Users         : 
	root@localhost  : 100.00% (1) of query, 75.00% (3) of all users
INSERT INTO c2 SELECT * FROM customer;
insert into c2 select * from customer;
____________________________________________________________________ 004 ___
Count         : 1  (25.00%)
Time          : 10.626176 s total, 10.626176 s avg, 10.626176 s to 10.626176 s max  (13.67%)
Lock Time (s) : 0 total, 0 avg, 0 to 0 max  (0.00%)
Rows sent     : 0 avg, 0 to 0 max  (0.00%)
Rows examined : 0 avg, 0 to 0 max  (0.00%)
Database      : tp2  QC_hit: No
Users         : 
	root@ 127.0.0.1 : 100.00% (1) of query, 25.00% (1) of all users
SET timestamp=N;
SET timestamp=1556042943;
*************************************************************************************************************************************************

Here is my [slow_query.log](https://github.com/daniel-nichter/hackmysql.com/files/3109373/slow_query.log)

*************************************************************************************************************************************************
Time                 Id Command    Argument
# Time: 190423  9:18:45
# User@Host: root[root] @ localhost []
# Thread_id: 6  Schema: tpcc  QC_hit: No
# Query_time: 19.394835  Lock_time: 0.264885  Rows_sent: 0  Rows_examined: 300000
# Rows_affected: 300000
use tpcc;
SET timestamp=1556036325;
create table c2 as select * from customer;
# Time: 190423  9:19:35
# User@Host: root[root] @ localhost []
# Thread_id: 6  Schema: tpcc  QC_hit: No
# Query_time: 14.671241  Lock_time: 0.000161  Rows_sent: 0  Rows_examined: 300000
# Rows_affected: 300000
SET timestamp=1556036375;
insert into c2 select * from customer;
# Time: 190423 10:49:08
# User@Host: root[root] @ localhost []
# Thread_id: 6  Schema: tpcc  QC_hit: No
# Query_time: 33.028730  Lock_time: 0.022156  Rows_sent: 746709  Rows_examined: 938
# Rows_affected: 0
SET timestamp=1556041748;
select * from customer a, customer b;
# Time: 190423 11:09:03
# User@Host: root[root] @  [127.0.0.1]
# Thread_id: 45  Schema: tp2  QC_hit: No
# Query_time: 10.626176  Lock_time: 0.000000  Rows_sent: 0  Rows_examined: 0
# Rows_affected: 0
use tp2;
SET timestamp=1556042943;
rollback;
# Time: 190423 11:11:38
# User@Host: root[root] @  [127.0.0.1]
# Thread_id: 45  Schema: tp2  QC_hit: No
# Query_time: 10.553370  Lock_time: 0.000000  Rows_sent: 0  Rows_examined: 0
# Rows_affected: 0
SET timestamp=1556043098;
rollback;